### PR TITLE
fix  kernels >= 5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
-(11.12.2009)
+(07.17.2019)
+1.6.0 -- fix kernels >= 5
 
 1.5.0 -- Minor Bugfixes: 
 -- Fixed compilation errors on older kernels and RHEL

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ fmem$(VERSION)-objs := lkm.o
 all:	clean fmem$(VERSION)
 
 fmem$(VERSION) : clean
-	make -C $(KERNEL_SRC_DIR) SUBDIRS=`pwd` modules
+	make -C $(KERNEL_SRC_DIR) KBUILD_EXTMOD=`pwd` modules
 
 install:
 	./run.sh

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-fmem 1.5.0
+fmem 1.6.0
 
 This repo is just a github mirror of the original fmem module.
 


### PR DESCRIPTION
```
'SUBDIRS' will be removed after Linux 5.3
use 'KBUILD_EXTMOD' instead
```